### PR TITLE
fix(http): prevent token-renewal busy-loop on failure and short-lived…

### DIFF
--- a/http/src/main/scala/com/github/chenharryhua/nanjin/http/client/auth/OAuth2.scala
+++ b/http/src/main/scala/com/github/chenharryhua/nanjin/http/client/auth/OAuth2.scala
@@ -216,6 +216,28 @@ private class AuthorizationCodeAuth[F[_]: Async](
     }
 }
 
-/** @note A 30-second skew is applied when scheduling token renewal to avoid race conditions. */
-private def skewed(expire: Long): FiniteDuration = // suggested by ChatGPT
-  (expire.seconds - 30.seconds).max(0.seconds)
+/** Renewal-scheduling strategy for token-based auth.
+  *
+  * Two floors keep the background renewal loop in [[TokenAuthClient.wrap]] from degenerating into a
+  * zero-delay busy loop:
+  *
+  *   - [[skewed]] governs the success path: it renews `SKEW` early so a request never races an expiring
+  *     token, but never schedules sooner than [[renewMinDelay]]. A provider issuing short-lived tokens
+  *     (`expires_in <= SKEW`) would otherwise collapse the delay to `0.seconds` and re-fetch immediately,
+  *     forever.
+  *   - [[renewFailureBackoff]] governs the failure path: when a renewal throws before reaching its own
+  *     `delayBy`, the loop waits this long before retrying, bounding CPU and auth-endpoint load.
+  */
+
+/** Renew this long before expiry to avoid racing an in-flight request against an expiring token. */
+private val SKEW: FiniteDuration = 30.seconds
+
+/** Lower bound on the scheduled-renewal delay, so short-lived tokens cannot drive a zero-delay loop. */
+private val renewMinDelay: FiniteDuration = 5.seconds
+
+/** Delay before the renewal loop retries after a failed renewal, bounding CPU / auth-endpoint load. */
+private val renewFailureBackoff: FiniteDuration = 5.seconds
+
+/** Schedule delay until the next renewal: `SKEW` before expiry, but never below [[renewMinDelay]]. */
+private def skewed(expire: Long): FiniteDuration =
+  (expire.seconds - SKEW).max(renewMinDelay)

--- a/http/src/main/scala/com/github/chenharryhua/nanjin/http/client/auth/TokenAuthClient.scala
+++ b/http/src/main/scala/com/github/chenharryhua/nanjin/http/client/auth/TokenAuthClient.scala
@@ -49,7 +49,14 @@ abstract private class TokenAuthClient[F[_], T](using F: Async[F]) extends Http4
   final def wrap(client: Client[F]): Resource[F, Client[F]] =
     for {
       authToken <- Resource.eval(getToken.flatMap(F.ref))
-      _ <- F.background[Nothing](renewToken(authToken).attempt.foreverM)
+      // Background renewal loop. `renewToken` schedules the next fetch via its own `delayBy`
+      // on the success path, but if it fails (network blip, decode error, short-lived token,
+      // ...) that internal delay may never be reached. Without a floor here, a persistently
+      // failing renewal would spin `foreverM` with zero delay, busy-looping the CPU and
+      // hammering the auth endpoint. `handleErrorWith` swallows the failure but enforces a
+      // minimum backoff before the loop retries, guaranteeing progress bounded from below.
+      _ <- F.background[Nothing](
+        renewToken(authToken).handleErrorWith(_ => F.sleep(renewFailureBackoff)).foreverM)
       singleFlight <- Resource.eval(SingleFlight[F, T])
     } yield Client[F] { request =>
       def runWithToken(token: T): Resource[F, Response[F]] =

--- a/http/src/test/scala/mtest/http/AuthLoginSuite.scala
+++ b/http/src/test/scala/mtest/http/AuthLoginSuite.scala
@@ -556,10 +556,48 @@ final class AuthLoginSuite extends CatsEffectSuite {
     auth.clientCredentials[IO](authClient, credential).flatMap(_.login(protectedResource)).use { authed =>
       for {
         _ <- authed.expect[String](uri"/a")
-        _ <- IO.sleep(2.seconds) // wait for renewal to fire
+        // expires_in=1 is shorter than the renewal skew, so the scheduled delay is clamped to
+        // the renewMinDelay floor (5s) rather than firing immediately. Wait past that floor.
+        _ <- IO.sleep(6.seconds)
         _ <- authed.expect[String](uri"/b")
         n <- tokenCalls.get
       } yield assert(n >= 2)
+    }
+  }
+
+  test("10a.failing renewal backs off instead of busy-looping the auth endpoint") {
+    // First fetch succeeds with a short-lived token; every subsequent renewal fails. Without a
+    // backoff floor the loop would spin `foreverM` with no delay and hammer the endpoint. With the
+    // fix, renewal attempts over a fixed window are bounded by renewFailureBackoff (~5s).
+    val tokenCalls = Ref.unsafe[IO, Int](0)
+
+    val app = HttpApp[IO] {
+      case POST -> Root / "token" =>
+        tokenCalls.updateAndGet(_ + 1).flatMap { n =>
+          if (n == 1)
+            Ok("""{"access_token":"t1","token_type":"Bearer","expires_in":1}""")
+          else
+            InternalServerError("renewal boom")
+        }
+      case _ => InternalServerError()
+    }
+
+    val authClient = Resource.pure[IO, Client[IO]](Client.fromHttpApp(app))
+    val credential = ClientCredentials(
+      auth_endpoint = uri"/token",
+      client_id = "id",
+      client_secret = "secret"
+    )
+
+    auth.clientCredentials[IO](authClient, credential).flatMap(_.login(protectedResource)).use { authed =>
+      for {
+        _ <- authed.expect[String](uri"/a")
+        _ <- IO.sleep(3.seconds) // shorter than the renewFailureBackoff floor
+        n <- tokenCalls.get
+      } yield
+        // initial fetch (1) + at most a couple of backed-off renewal attempts.
+        // A busy loop would produce hundreds/thousands here.
+        assert(n <= 3, s"expected the renewal loop to back off, but it made $n token calls")
     }
   }
 


### PR DESCRIPTION
… tokens

The background renewal loop used renewToken.attempt.foreverM, which swallowed failures and retried with no delay, and skewed(expire) floored at 0.seconds so tokens with expires_in <= 30 scheduled immediate re-fetches. Together these could busy-loop the CPU and hammer the auth endpoint.

- skewed now floors at renewMinDelay (5s) instead of 0s, so short-lived tokens cannot drive a zero-delay schedule.
- the renewal loop backs off by renewFailureBackoff (5s) via handleErrorWith before retrying, bounding load when a renewal fails before its own delayBy. This is the shared TokenAuthClient path, so Salesforce is covered too.
- document the two-floor strategy on the OAuth2 timing constants.

Adjust AuthLoginSuite #10 (relied on the old 0s floor) and add #10a asserting a persistently-failing renewal makes a bounded number of token calls.

Fixes #4335