### PR TITLE
fix(guard): guard indexFilter divisor and close WebSocket subscribe race

### DIFF
--- a/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/event/EventPipe.scala
+++ b/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/event/EventPipe.scala
@@ -93,7 +93,16 @@ object EventPipe {
         }
     }
 
-  def indexFilter(divisor: Int): EventPipe =
+  /** Keep every `divisor`-th periodic [[MetricsSnapshot]] (by tick index); other events pass through
+    * unchanged.
+    *
+    * @param divisor
+    *   must be `>= 1`. Validated eagerly so a misconfiguration fails at construction with a clear message,
+    *   rather than throwing `ArithmeticException` (`/ by zero`) or silently misfiltering (negative values) on
+    *   the first periodic snapshot.
+    */
+  def indexFilter(divisor: Int): EventPipe = {
+    require(divisor >= 1, s"indexFilter divisor must be >= 1, but was $divisor")
     new EventPipe {
       override def apply(event: Event): Option[Event] =
         event match {
@@ -105,6 +114,7 @@ object EventPipe {
           case other => Some(other)
         }
     }
+  }
 
   def windowFilter(interval: FiniteDuration): EventPipe =
     new EventPipe {

--- a/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/service/dashboard/HttpWsRouter.scala
+++ b/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/service/dashboard/HttpWsRouter.scala
@@ -59,9 +59,15 @@ final private class HttpWsRouter[F[_]: Async](
 
       case GET -> Root        => Ok(home_page)
       case GET -> Root / "ws" =>
-        val preserved = Stream.eval(history.value).flatMap(Stream.emits)
+        // Register the topic subscription *before* snapshotting history, so a sample published in
+        // the window between the two cannot fall into neither. `subscribeAwait` acquires the
+        // subscriber eagerly on Resource acquisition (unlike `subscribe`, which registers lazily
+        // when the stream is first pulled). A sample straddling the boundary may appear in both the
+        // history snapshot and the live stream; a duplicated chart point is harmless, a gap is not.
         val send: Stream[F, WebSocketFrame] =
-          (preserved ++ topic.subscribe(5)).map(text)
+          Stream.resource(topic.subscribeAwait(5)).flatMap { live =>
+            (Stream.evalSeq(history.value) ++ live).map(text)
+          }
 
         val receive: Pipe[F, WebSocketFrame, Unit] = _.evalMap(_ => ().pure[F])
 

--- a/guard/src/test/scala/mtest/guard/EventPipeEdgeCaseTest.scala
+++ b/guard/src/test/scala/mtest/guard/EventPipeEdgeCaseTest.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import com.github.chenharryhua.nanjin.common.logging.LogLevel
 import com.github.chenharryhua.nanjin.guard.TaskGuard
 import com.github.chenharryhua.nanjin.guard.event.Event.*
-import com.github.chenharryhua.nanjin.guard.event.Event.MetricsSnapshot.Index.{Adhoc, Periodic}
+import com.github.chenharryhua.nanjin.guard.event.Event.MetricsSnapshot.Index.Periodic
 import com.github.chenharryhua.nanjin.guard.event.{Event, EventPipe}
 import cats.syntax.order.catsSyntaxPartialOrder
 import org.scalatest.funsuite.AnyFunSuite
@@ -149,54 +149,18 @@ class EventPipeEdgeCaseTest extends AnyFunSuite {
 
   // --- indexFilter divisor=0 ---
 
-  test("8.EventPipe.indexFilter(0) throws ArithmeticException on periodic metrics") {
-    val events = service
-      .eventStream(_ => IO.sleep(2.seconds))
-      .map(checkJson)
-      .compile
-      .toList
-      .unsafeRunSync()
-
-    // Applying indexFilter(0) to a periodic MetricsSnapshot should throw ArithmeticException (/ by zero)
-    val periodicEvent = events.find {
-      case MetricsSnapshot(_, _, index, _, _) => index.isInstanceOf[Periodic]
-      case _                                  => false
-    }
-    assert(periodicEvent.isDefined)
-    assertThrows[ArithmeticException] {
-      EventPipe.indexFilter(0).filter(periodicEvent.get)
+  test("8.EventPipe.indexFilter(0) is rejected eagerly at construction") {
+    // divisor=0 would divide by zero; the require guard fails fast, before any event is filtered.
+    assertThrows[IllegalArgumentException] {
+      EventPipe.indexFilter(0)
     }
   }
 
-  test("9.EventPipe.indexFilter(0) passes non-periodic events through") {
-    val events = service
-      .eventStream(agent => agent.adhoc.report)
-      .map(checkJson)
-      .compile
-      .toList
-      .unsafeRunSync()
-
-    val startEvent = events.find(_.isInstanceOf[ServiceStart])
-    assert(startEvent.isDefined)
-    // ServiceStart should pass through even with divisor=0
-    assert(EventPipe.indexFilter(0).filter(startEvent.get))
-  }
-
-  test("10.EventPipe.indexFilter(0) passes adhoc metrics through") {
-    val events = service
-      .eventStream(agent => agent.adhoc.report)
-      .map(checkJson)
-      .compile
-      .toList
-      .unsafeRunSync()
-
-    val adhocEvent = events.find {
-      case MetricsSnapshot(_, _, index, _, _) => index.isInstanceOf[Adhoc]
-      case _                                  => false
+  test("9.EventPipe.indexFilter with a negative divisor is rejected eagerly at construction") {
+    // negative divisors would silently misfilter; the require guard rejects them up front.
+    assertThrows[IllegalArgumentException] {
+      EventPipe.indexFilter(-1)
     }
-    assert(adhocEvent.isDefined)
-    // Adhoc snapshots should pass through regardless of divisor
-    assert(EventPipe.indexFilter(0).filter(adhocEvent.get))
   }
 
   // --- indexFilter divisor=1 ---


### PR DESCRIPTION
EventPipe.indexFilter divided by its divisor per periodic snapshot, so divisor=0 threw ArithmeticException lazily and negatives misfiltered silently. Validate divisor >= 1 eagerly with require, failing fast at construction with a clear message. Rewrite the edge-case tests to assert the eager rejection.

HttpWsRouter read history.value before topic.subscribe registered (subscribe registers lazily on first pull), so a sample published in between fell into neither the snapshot nor the live stream, gapping a new client's chart. Use topic.subscribeAwait, which registers the subscriber eagerly on Resource acquisition, then snapshot history. A boundary sample may now be delivered twice (harmless duplicate) rather than lost.

Item #3 (watchdog backoff timestamp) intentionally left as-is: anchoring the threshold to the scheduled tick conclude is consistent with the tick model.

Fixes #4338