### PR TITLE
fix(common): preserve xml sibling order for multi-label elements

### DIFF
--- a/common/src/main/scala/com/github/chenharryhua/nanjin/common/xml/xmlNodeCodec.scala
+++ b/common/src/main/scala/com/github/chenharryhua/nanjin/common/xml/xmlNodeCodec.scala
@@ -130,8 +130,18 @@ private def element(elem: Elem): Json = {
     val textField =
       Option.when(text.nonEmpty)("#text" -> Json.fromString(text)).toSeq
 
+    // Emit the order-preserving "#children" array whenever child order could otherwise be lost:
+    //   - text is interleaved with elements (grouped-by-label form would drop the text position), or
+    //   - there is more than one distinct element label (grouping by label loses the interleaving,
+    //     e.g. <a/><b/><a/> would collapse to {"a":[..],"b":..} and decode back as <a/><a/><b/>).
+    // A single repeated label (e.g. <user/><user/>) keeps order within its own array, so no
+    // "#children" is needed there.
+    val hasText = orderedNodes.exists(_.isLeft)
+    val hasElem = orderedNodes.exists(_.isRight)
+    val multipleLabels = children.map(_.label).distinct.sizeIs > 1
+
     val orderedChildrenField =
-      Option.when(orderedNodes.exists(_.isLeft) && orderedNodes.exists(_.isRight)) {
+      Option.when(hasText && hasElem || multipleLabels) {
         "#children" -> Json.arr(orderedNodes.map {
           case Left(t)      => Json.obj("#text" -> Json.fromString(t))
           case Right(child) => Json.obj(child.label -> element(child))

--- a/common/src/test/scala/mtest/common/XmlNodeJsonCodecTest.scala
+++ b/common/src/test/scala/mtest/common/XmlNodeJsonCodecTest.scala
@@ -156,4 +156,46 @@ class XmlNodeJsonCodecTest extends AnyFunSuite {
 
     assert(encode(decoded) == json)
   }
+
+  test("13.interleaved same-level elements with no text preserve order via #children") {
+    // <a/><b/><a/>: two distinct labels interleaved, no text. Grouping by label alone would lose
+    // that `b` sits between the two `a` elements. #children must capture the original order.
+    val xml = XML.loadString("<root><a>1</a><b>2</b><a>3</a></root>")
+
+    val expected = Json.obj(
+      "root" -> Json.obj(
+        "a" -> List("1", "3").asJson,
+        "b" -> Json.fromString("2"),
+        "#children" -> List(
+          Json.obj("a" -> Json.fromString("1")),
+          Json.obj("b" -> Json.fromString("2")),
+          Json.obj("a" -> Json.fromString("3"))
+        ).asJson
+      ))
+
+    assert(encode(xml) == expected)
+  }
+
+  test("14.interleaved multi-label element survives xml-json-xml-json round trip") {
+    val xml = XML.loadString("<root><a>1</a><b>2</b><a>3</a></root>")
+
+    val encoded = encode(xml)
+    val decoded = decode(encoded)
+
+    // decode must reconstruct the interleaved order, and re-encoding must reproduce the same JSON.
+    assert(encode(decoded) == encoded)
+    assert(decoded.child.collect { case e: scala.xml.Elem => e.label }.toList == List("a", "b", "a"))
+  }
+
+  test("15.single repeated label stays a grouped array without #children") {
+    // Guard the format boundary: one distinct label keeps order within its array, so no #children.
+    val xml = XML.loadString("<root><a>1</a><a>2</a></root>")
+
+    val expected = Json.obj(
+      "root" -> Json.obj(
+        "a" -> List("1", "2").asJson
+      ))
+
+    assert(encode(xml) == expected)
+  }
 }


### PR DESCRIPTION
xmlNodeCodec only emitted the order-preserving #children array when text and elements were interleaved. An element with no text but multiple differently labelled children (e.g. <a/><b/><a/>) fell back to grouping by label, which dropped the interleaving: it encoded as {"a":[a1,a2],"b":b} and decoded back as <a/><a/><b/>, silently reordering the document.

Emit #children whenever child order could be lost: interleaved text+elements (as before) or more than one distinct element label. A single repeated label keeps order within its own array, so it stays a plain grouped array.

Wire-format note: elements with >= 2 distinct child labels and no interleaved text now gain a #children field they previously lacked. Single-label and text-mixed shapes are unchanged.

Fixes #4336