### PR TITLE
Document batch id counter semantics

### DIFF
--- a/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/batch/data.scala
+++ b/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/batch/data.scala
@@ -48,7 +48,12 @@ object BatchMode:
   given Encoder[BatchMode] = Encoder.encodeString.contramap(_.show)
 end BatchMode
 
-/** Metadata describing a single batch step and the execution context in which it ran. */
+/** Metadata describing a single batch step and the execution context in which it ran.
+  *
+  * @param batchId
+  *   identifier of the batch this job belongs to; a per-service-instance monotonic counter starting at 1. See
+  *   [[BatchResult.batchId]] for the full semantics.
+  */
 final case class Job(
   name: String,
   index: Int,
@@ -143,7 +148,17 @@ sealed trait BatchResult[A] {
   /** Sequential, parallel, or monadic execution mode. */
   def mode: BatchMode
 
-  /** Unique identifier for this execution. */
+  /** Identifier for this batch execution.
+    *
+    * A monotonic counter, starting at 1, minted from a single `AtomicLong` created per service instance.
+    * Successive batches within the same instance receive 1, 2, 3, … in the order they are launched, so the
+    * latest value also reveals how many batches the instance has run.
+    *
+    * The id is unique '''within a service instance''', not globally: a new instance (a new `serviceId`, e.g.
+    * on redeploy) starts its counter over at 1. Cross-instance correlation therefore relies on the enclosing
+    * event's `serviceId`, which is why the id is a plain counter rather than a random UUID. It is emitted as
+    * the JSON number `batch_id`.
+    */
   def batchId: Long
 
   /** Per-job result values represented by this result type. */

--- a/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/service/ServiceGuard.scala
+++ b/guard/src/main/scala/com/github/chenharryhua/nanjin/guard/service/ServiceGuard.scala
@@ -135,6 +135,7 @@ private[guard] object ServiceGuard {
             brief = Brief(jsons.filterNot(_.isNull).distinct.asJson),
             host = Host(hostName, esb.map(_.port.value).map(Port(_)))
           )
+          // one counter per service instance; hands out batch ids 1, 2, 3, … via getAndIncrement
           KickedOff(params, esb, new AtomicLong(1L))
         }
       }


### PR DESCRIPTION
Explain the per-service-instance monotonic batch id on BatchResult.batchId (1-based, reveals how many batches an instance has run, unique within an instance, resets on redeploy, cross-instance correlation via serviceId, emitted as the batch_id JSON number). Cross-reference it from Job.batchId and note at the counter's creation in ServiceGuard that it is one AtomicLong per service instance.